### PR TITLE
Add .nojekyll to docs folder

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements_dev.txt
     - name: Build Sphinx HTML documentation
-      run: sphinx-build -b html docs/source docs/build/html
+      run: | 
+        sphinx-build -b html docs/source docs/build/html
+        touch docs/build/html/.nojekyll
     - name: Archive documentation
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This disables jekyll in GH Pages and just serves the index.html... hopefully