### PR TITLE
Hotfix: Broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-For the entire documentation please see [https://cirosec-studis.github.io/python-zimbra-web](https://cirosec-studis.github.io/python-zimbra-web]).
+For the entire documentation please see [https://cirosec-studis.github.io/python-zimbra-web](https://cirosec-studis.github.io/python-zimbra-web).
 
 The documentation for the develop branch can be found here: [https://cirosec-studis.github.io/python-zimbra-web/develop/](https://cirosec-studis.github.io/python-zimbra-web/develop)
 

--- a/src/zimbraweb/__init__.py
+++ b/src/zimbraweb/__init__.py
@@ -11,7 +11,7 @@ import requests
 
 import zimbraweb.emlparsing
 
-__version__ = '2.0'
+__version__ = '2.0.1'
 
 
 @dataclass


### PR DESCRIPTION
The documentation link had an additional `]`
🤦 