### PR TITLE
Hotfix 2.0.2

### DIFF
--- a/src/zimbraweb/__init__.py
+++ b/src/zimbraweb/__init__.py
@@ -11,7 +11,7 @@ import requests
 
 import zimbraweb.emlparsing
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 
 @dataclass

--- a/src/zimbraweb/emlparsing.py
+++ b/src/zimbraweb/emlparsing.py
@@ -39,7 +39,7 @@ def parse_eml(eml: str) -> Dict[str, Union[str, List[Any]]]:
 
     ct = parsed.get_content_type()
     if ct == "text/plain":
-        out["body"] = parsed.get_payload()
+        out["body"] = parsed.get_payload(decode=True).decode(parsed.get_content_charset())
     elif ct == "multipart/mixed":
         out["attachments"] = []
         for part in parsed.get_payload():


### PR DESCRIPTION
Closes #66 

The payload was not decoded properly when the content type was `text/plain`.