### PR TITLE
Add is_parsable function to emlparsing

### DIFF
--- a/src/zimbraweb/emlparsing.py
+++ b/src/zimbraweb/emlparsing.py
@@ -62,3 +62,20 @@ def parse_eml(eml: str) -> Dict[str, Union[str, List[Any]]]:
         raise ContentTypeNotSupportedError(f"Content-Type: {ct} not supported")
 
     return out
+
+
+def is_parsable(eml: str) -> bool:
+    """Check eml string for parsability
+
+    Args:
+        eml (str): The EML string to parse.
+
+    Returns:
+        bool if parse_eml() will throw an error.
+    """
+    
+    try:
+        parse_eml(eml)
+        return True
+    except:
+        return False


### PR DESCRIPTION
This function will return a bool value for the parsing instead of throwing an error, which makes it usable in if-statements.